### PR TITLE
Visual Studio recognizes .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 root = true
-[*.{cs}]
+[*.cs]
 charset=utf-8-bom
 indent_style=space
 indent_size=4


### PR DESCRIPTION
VS 2022 was not applying the .editorconfig settings on my end.  Fixed.